### PR TITLE
change header to say "Get the client here"

### DIFF
--- a/src/main/webapp/src/app/DeployApp/AppReport.tsx
+++ b/src/main/webapp/src/app/DeployApp/AppReport.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 const DeployAppReport = ({ appReports }) => {
   return (
     <PageSection>
-      <Title headingLevel="h1" size="xl">Join now: <a href="https://red.ht/cs-workshop-scoreboard" target="_blank">https://red.ht/cs-workshop-scoreboard</a></Title>
+      <Title headingLevel="h1" size="xl">Get the client here: <a href="https://red.ht/cs-workshop-scoreboard" target="_blank">https://red.ht/cs-workshop-scoreboard</a></Title>
 
       <CodeBlock>
         <CodeBlockCode id="code-content">SCOREBOARD_SERVER={window.location.href.replace(/\/deploy-the-app$/i, "")}</CodeBlockCode><br/>

--- a/src/main/webapp/src/app/DeployCluster/ClusterReport.tsx
+++ b/src/main/webapp/src/app/DeployCluster/ClusterReport.tsx
@@ -4,7 +4,7 @@ import { PageSection, Title, ProgressStepper, ProgressStep, CodeBlock, CodeBlock
 const DeployClusterReport = ({ clusterReports }) => {
   return (
     <PageSection>
-      <Title headingLevel="h1" size="xl">Join now: <a href="https://red.ht/cs-workshop-scoreboard" target="_blank">https://red.ht/cs-workshop-scoreboard</a></Title>
+      <Title headingLevel="h1" size="xl">Get the client here: <a href="https://red.ht/cs-workshop-scoreboard" target="_blank">https://red.ht/cs-workshop-scoreboard</a></Title>
       <CodeBlock>
         <CodeBlockCode id="code-content">SCOREBOARD_SERVER={window.location.href.replace(/\/$/i, "")}</CodeBlockCode><br/>
       </CodeBlock>


### PR DESCRIPTION
In an attempt to limit ambiguity of attendees, I have replaced "Join now" with "Get the client here", which will improve the lives of all involved and change the world for the better, albeit slightly. 